### PR TITLE
Handle legend truncation

### DIFF
--- a/Source/Charts/Components/Legend.swift
+++ b/Source/Charts/Components/Legend.swift
@@ -283,7 +283,8 @@ open class Legend: ComponentBase
                 maxWidth = max(maxWidth, width)
             }
             
-            neededWidth = maxWidth
+            let legendMaxWidth: CGFloat = viewPortHandler.chartWidth * maxSizePercent
+            neededWidth = min(legendMaxWidth, maxWidth)
             neededHeight = maxHeight
             
         case .horizontal:

--- a/Source/Charts/Renderers/LegendRenderer.swift
+++ b/Source/Charts/Renderers/LegendRenderer.swift
@@ -570,6 +570,26 @@ open class LegendRenderer: Renderer
     /// Draws the provided label at the given position.
     @objc open func drawLabel(context: CGContext, x: CGFloat, y: CGFloat, label: String, font: NSUIFont, textColor: NSUIColor)
     {
-        ChartUtils.drawText(context: context, text: label, point: CGPoint(x: x, y: y), align: .left, attributes: [NSAttributedString.Key.font: font, NSAttributedString.Key.foregroundColor: textColor])
+        let paragrahStyle = NSMutableParagraphStyle()
+        paragrahStyle.lineBreakMode = .byTruncatingMiddle
+        
+        let rect = CGRect(
+            x: 0,
+            y: 0,
+            width: viewPortHandler.chartWidth - (legend?.xOffset ?? 0),
+            height: viewPortHandler.chartHeight
+        )
+        
+        ChartUtils.drawText(
+            context: context,
+            contentRect: rect,
+            text: label,
+            point: CGPoint(x: x, y: y),
+            align: .left,
+            attributes: [
+                NSAttributedString.Key.font: font,
+                NSAttributedString.Key.foregroundColor: textColor,
+                NSAttributedString.Key.paragraphStyle: paragrahStyle]
+        )
     }
 }

--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -164,7 +164,7 @@ open class ChartUtils
         NSUIGraphicsPopContext()
     }
     
-    open class func drawText(context: CGContext, text: String, point: CGPoint, align: NSTextAlignment, attributes: [NSAttributedString.Key : Any]?)
+    open class func drawText(context: CGContext, contentRect: CGRect = CGRect.zero,text: String, point: CGPoint, align: NSTextAlignment, attributes: [NSAttributedString.Key : Any]?)
     {
         var point = point
         
@@ -179,7 +179,13 @@ open class ChartUtils
         
         NSUIGraphicsPushContext(context)
         
-        (text as NSString).draw(at: point, withAttributes: attributes)
+        if contentRect != CGRect.zero
+        {
+            let rect = CGRect(x: point.x, y: point.y, width: contentRect.size.width - point.x, height: contentRect.size.height - point.y)
+            (text as NSString).draw(in: rect, withAttributes: attributes)
+        } else {
+            (text as NSString).draw(at: point, withAttributes: attributes)
+        }
         
         NSUIGraphicsPopContext()
     }


### PR DESCRIPTION
## JIRA
- [ORCHID-2677](https://cipherhealth.atlassian.net/browse/ORCHID-2677)

## Description
This PR solves issue with legend when text is too long. 

In this scenario, it was not calculating maximum legend width correctly and it was not taking into account legend boundaries when rendering legend texts.

## Screenshots
![Screenshot 2020-04-28 at 16 54 40](https://user-images.githubusercontent.com/2726409/80505509-b5f27980-8974-11ea-8b62-8234f8e5c2a7.png)

![Screenshot 2020-04-28 at 16 54 47](https://user-images.githubusercontent.com/2726409/80505567-c60a5900-8974-11ea-9f2f-49cba83f89ab.png)

